### PR TITLE
feat(frontend): add number of connections in navbar

### DIFF
--- a/frontend/src/app/_nav.ts
+++ b/frontend/src/app/_nav.ts
@@ -9,7 +9,12 @@ export const navItems: INavData[] = [
   {
     name: 'connections',
     url: '/icons',
-    icon: 'icon-star',
+    icon: 'fa fa-cloud',
+    badge: {
+      text: '',
+      variant: 'primary',
+      class: '',
+    },
     children: [
      
     ]

--- a/frontend/src/app/containers/default-layout/default-layout.component.ts
+++ b/frontend/src/app/containers/default-layout/default-layout.component.ts
@@ -40,6 +40,7 @@ export class DefaultLayoutComponent implements OnInit {
 
   private pushClusterMenuItem(res: ClusterResult){
     const currentUser = this.auth.currentUser()
+    this.navItems[1].badge.text = `  ${res.data.length}`;
     this.navItems[1].children = res.data
     .filter(c=> currentUser.isAdmin || c.users.findIndex(u=> u.userId == currentUser.userId) > -1)
     .map(d=> {


### PR DESCRIPTION
Added a badge next to connection navigation in order to show the number of connections, also i changed the icon to a cloud icon

![image](https://user-images.githubusercontent.com/8146379/135728499-93b568f5-0c81-4e32-97af-dc46e294027e.png)
